### PR TITLE
Now when someone switch from Base to Base Sepolia all components stay…

### DIFF
--- a/components/SmartWalletInfo.tsx
+++ b/components/SmartWalletInfo.tsx
@@ -60,7 +60,11 @@ export default function SmartWalletInfo({
               Smart Wallet
             </label>
             <div className="relative">
-              <div className="w-full px-3 py-2 border border-gray-300 rounded-md">
+              <div
+                className={`w-full px-3 py-2 border border-gray-300 rounded-md ${
+                  smartWalletAddress ? "" : "h-[42px]"
+                }`}
+              >
                 {smartWalletAddress}
               </div>
               {/* Copy button with success indicator */}
@@ -86,7 +90,8 @@ export default function SmartWalletInfo({
             `, ${formatUnits(smartWalletUsdcBalance, 6)} USDC`}
         </div>
         {/* Display USDC faucet link on testnet */}
-        {chainId === baseSepolia.id.toString() && (
+        {/* Added some empty space to make it look better when the chain change from Base to Base Sepolia*/}
+        {chainId === baseSepolia.id.toString() ? (
           <div className="text-xs mt-1">
             <a
               href="https://faucet.circle.com/"
@@ -96,6 +101,8 @@ export default function SmartWalletInfo({
               USDC Sepolia Faucet
             </a>
           </div>
+        ) : (
+          <div className="mt-1 h-[16px]">{""}</div>
         )}
       </div>
     </div>

--- a/components/WalletInfo.tsx
+++ b/components/WalletInfo.tsx
@@ -88,7 +88,7 @@ export default function WalletInfo({
             `, ${formatUnits(embeddedUsdcBalance, 6)} USDC`}
         </div>
         {/* Display USDC faucet link on testnet */}
-        {chainId === baseSepolia.id.toString() && (
+        {chainId === baseSepolia.id.toString() ? (
           <div className="text-xs mt-1">
             <a
               href="https://faucet.circle.com/"
@@ -98,6 +98,8 @@ export default function WalletInfo({
               USDC Sepolia Faucet
             </a>
           </div>
+        ) : (
+          <div className="mt-1 h-[16px]">{""}</div>
         )}
       </div>
     </div>


### PR DESCRIPTION
… in the same position. I've also made the input for the Smart Wallet tall 42px when there isn't a smart wallet address. I've noticed that if you haven't a smart wallet the input was very short and the Copy Icon was outside the input. 